### PR TITLE
Add devcontainer support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
+{
+  "name": "Automated Ai Web Researcher Ollama Devcontainer",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "features": {
+    "ghcr.io/nils-geistmann/devcontainers-features/zsh": {}
+  },
+
+	"dockerComposeFile": "docker-compose.yml",  // Features to add to the dev container. More info: https://containers.dev/features.
+  "service": "web",
+  "workspaceFolder": "/app",
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "pip install -r requirements.txt",
+  "postStartCommand": "python Web-LLM.py",
+
+  "overrideCommand": true
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+
+services:
+  web:
+    image: mcr.microsoft.com/devcontainers/python:3
+    ports:
+      - "80:80"
+      - "11434:11434"
+    volumes:
+      - ..:/app
+    extra_hosts: 
+      - "host.docker.internal:host-gateway"

--- a/llm_config.py
+++ b/llm_config.py
@@ -22,6 +22,7 @@ LLM_CONFIG_LLAMA_CPP = {
 # LLM settings for Ollama
 LLM_CONFIG_OLLAMA = {
     "llm_type": "ollama",
+    # change base_url to http://host.docker.internal:11434 in devcontainer
     "base_url": "http://localhost:11434",  # default Ollama server URL
     "model_name": "custom-phi3-32k-Q4_K_M",  # Replace with your Ollama model name
     "temperature": 0.7,


### PR DESCRIPTION
this PR adds devcontainer support for this project, see https://code.visualstudio.com/docs/devcontainers/containers for all the features

It allows user to set up the AI Web researcher without installing python or anything, just their IDE with vscode and devcontainer extension. It also installs dependencies and runs the research

I think it complements #29 

## Caveat

Before researching, you have to change `llm_config.py`:

```diff
-    "base_url": "http://localhost:11434",
+    "base_url": "http://host.docker.internal:11434",
```

I do wonder if we can improve this configuration...