### PR TITLE
Update requirements.txt - fix windows-curses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ beautifulsoup4
 trafilatura
 readchar
 keyboard
-curses-windows; sys_platform == 'win32'
+windows-curses; sys_platform == 'win32'
 tqdm
 urllib3
 openai>=1.0.0


### PR DESCRIPTION
Change curses-windows to windows-curses as curses-windows does not exist.

Fixes requirements document for windows based systems.