### PR TITLE
Add Docker Support on feature/docker-support Branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Use an official Python runtime as a parent image
+FROM python:3.11-slim
+
+# Install gcc and g++ to prevent llama-cpp-python build error
+RUN apt-get update && apt-get install -y gcc g++
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements so they only have to be installed once
+COPY requirements.txt .
+
+# Install packages
+RUN pip install -r requirements.txt
+
+# Copy the current directory contents into the container at /app
+COPY . .
+
+# Make port 80 available to the world outside this container
+EXPOSE 80
+
+# Run Web-LLM.py when the container launches
+CMD ["python", "Web-LLM.py"]

--- a/README.md
+++ b/README.md
@@ -2,20 +2,6 @@
 # Docker Support (Linux Only)
 This branch supports Docker, but because of the hosting only on Linux as of now.
 
-Ensure that you have configured the model and that Ollama is running. Then, to build and run the app, follow these steps:
-## Docker Setup
-1. Build the Docker image:
-   
-    ```sh
-    docker build -t automated-ai-web-researcher .
-    ```
-
-2. Run the Docker container:
-   
-    ```sh
-    docker run -it --rm --network host automated-ai-web-researcher
-    ```
-
 ## Description
 Automated-AI-Web-Researcher is an innovative research assistant that leverages locally run large language models through Ollama to conduct thorough, automated online research on any given topic or question. Unlike traditional LLM interactions, this tool actually performs structured research by breaking down queries into focused research areas, systematically investigating each area via web searching and scraping relevant websites, and compiling its findings. The findings are automatically saved into a text document with all the content found and links to the sources. Whenever you want it to stop its research, you can input a command, which will terminate the research. The LLM will then review all of the content it found and provide a comprehensive final summary of your original topic or question. Afterward, you can ask the LLM questions about its research findings.
 
@@ -51,7 +37,7 @@ The key distinction is that this isn't just a chatbot—it's an automated resear
 - Research conversation mode for exploring findings
 
 ## Installation
-**Note:** To use on Windows, follow the instructions on the [/feature/windows-support](https://github.com/TheBlewish/Automated-AI-Web-Researcher-Ollama/tree/feature/windows-support) branch. For Linux and MacOS, use this main branch and the follow steps below:
+**Note:** This can only use Docker on Linux or WSL. For other uses, see the `main` and other branches.
 
 1. **Clone the repository:**
 
@@ -60,20 +46,13 @@ The key distinction is that this isn't just a chatbot—it's an automated resear
     cd Automated-AI-Web-Researcher-Ollama
     ```
 
-2. **Create and activate a virtual environment:**
+2. **Checkout the `feature/docker-support` branch:**
 
-    ```sh
-    python -m venv venv
-    source venv/bin/activate
-    ```
+   ```sh
+   git checkout -b feature/docker-support origin/feature/docker-support
+   ```
 
-3. **Install dependencies:**
-
-    ```sh
-    pip install -r requirements.txt
-    ```
-
-4. **Install and configure Ollama:**
+3. **Install and configure Ollama:**
 
     Install Ollama following the instructions at [https://ollama.ai](https://ollama.ai).
 
@@ -97,19 +76,19 @@ The key distinction is that this isn't just a chatbot—it's an automated resear
 
     **Note:** This specific configuration is necessary as recent Ollama versions have reduced context windows on models like `phi3:3.8b-mini-128k-instruct` despite the name suggesting high context, which is why the `modelfile` step is necessary due to the large amount of information used during the research process.
 
-5. Go to the llm_config.py file which should hav an ollama section that looks like this:
+4. Go to the llm_config.py file which should hav an ollama section that looks like this:
 
-```sh
-LLM_CONFIG_OLLAMA = {
-    "llm_type": "ollama",
-    "base_url": "http://localhost:11434",  # default Ollama server URL
-    "model_name": "custom-phi3-32k-Q4_K_M",  # Replace with your Ollama model name
-    "temperature": 0.7,
-    "top_p": 0.9,
-    "n_ctx": 55000,
-    "context_length": 55000,
-    "stop": ["User:", "\n\n"]
-```
+   ```sh
+   LLM_CONFIG_OLLAMA = {
+       "llm_type": "ollama",
+       "base_url": "http://localhost:11434",  # default Ollama server URL
+       "model_name": "custom-phi3-32k-Q4_K_M",  # Replace with your Ollama model name
+       "temperature": 0.7,
+       "top_p": 0.9,
+       "n_ctx": 55000,
+       "context_length": 55000,
+       "stop": ["User:", "\n\n"]
+   ```
 
 Then change to the left of where it says replace with your Ollama model name, the "model_name" function, to the name of the model you have setup in Ollama to use with the program.
    
@@ -121,24 +100,30 @@ Then change to the left of where it says replace with your Ollama model name, th
     ollama serve
     ```
 
-2. **Run the researcher:**
-
+2. **Build the Docker image:**
+   
     ```sh
-    python Web-LLM.py
+    docker build -t automated-ai-web-researcher .
     ```
 
-3. **Start a research session:**
+3. **Run the Docker container:**
+   
+    ```sh
+    docker run -it --rm --network host automated-ai-web-researcher
+    ```
+
+4. **Start a research session:**
     - Type `@` followed by your research query.
     - Press `CTRL+D` to submit.
     - Example: `@What year is the global population projected to start declining?`
 
-4. **During research, you can use the following commands by typing the associated letter and submitting with `CTRL+D`:**
+5. **During research, you can use the following commands by typing the associated letter and submitting with `CTRL+D`:**
     - Use `s` to show status.
     - Use `f` to show the current focus.
     - Use `p` to pause and assess research progress, which will give you an assessment from the LLM after reviewing the entire research content to determine whether it can answer your query with the content collected so far. It will then wait for you to input one of two commands: `c` to continue with the research or `q` to terminate it, resulting in a summary as if you had terminated it without using the pause feature.
     - Use `q` to quit research.
 
-5. **After the research completes:**
+6. **After the research completes:**
     - Wait for the summary to be generated and review the LLM's findings.
     - Enter conversation mode to ask specific questions about its findings.
     - Access the detailed research content found, available in a research session text file which will be located in the program's directory. This includes:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,20 @@
 # Automated-AI-Web-Researcher-Ollama
+# Docker Support (Linux Only)
+This branch supports Docker, but because of the hosting only on Linux as of now.
+
+Ensure that you have configured the model and that Ollama is running. Then, to build and run the app, follow these steps:
+## Docker Setup
+1. Build the Docker image:
+   
+    ```sh
+    docker build -t automated-ai-web-researcher .
+    ```
+
+2. Run the Docker container:
+   
+    ```sh
+    docker run -it --rm --network host automated-ai-web-researcher
+    ```
 
 ## Description
 Automated-AI-Web-Researcher is an innovative research assistant that leverages locally run large language models through Ollama to conduct thorough, automated online research on any given topic or question. Unlike traditional LLM interactions, this tool actually performs structured research by breaking down queries into focused research areas, systematically investigating each area via web searching and scraping relevant websites, and compiling its findings. The findings are automatically saved into a text document with all the content found and links to the sources. Whenever you want it to stop its research, you can input a command, which will terminate the research. The LLM will then review all of the content it found and provide a comprehensive final summary of your original topic or question. Afterward, you can ask the LLM questions about its research findings.


### PR DESCRIPTION
#14 #57 

Note: Because of the `--network host` this currently only works with Docker on Linux or WSL, which is why I put it in a separate branch.

This is because using `http://host.docker.internal:11434` on my system in `llm_config.py` did not connect to Ollama, while `--network host` did (which can only be used on Linux or WSL).

#29 Had a few errors and inefficiencies like downloading `requirements.txt` every time a change to the codebase was made and using `docker-compose up` which is not as universal as `docker compose up` (the former doesn't work on WSL out of the box, for example), but this PR is based on that.