### PR TITLE
Added a variable for users to change for offloading to GPU

### DIFF
--- a/llm_config.py
+++ b/llm_config.py
@@ -10,7 +10,7 @@ LLM_CONFIG_OLLAMA = {
     "temperature": 0.7,
     "top_p": 0.9,
     "n_ctx": 55000,
-    "num_gpu": 0, # 0 for CPU usage, 1 for offloading to GPU1
+    "num_gpu": 0, # e.g 0 for CPU usage, 1 for offloading to GPU1; defaults to 0
     "stop": ["User:", "\n\n"]
 }
 

--- a/llm_config.py
+++ b/llm_config.py
@@ -10,6 +10,7 @@ LLM_CONFIG_OLLAMA = {
     "temperature": 0.7,
     "top_p": 0.9,
     "n_ctx": 55000,
+    "num_gpu": 0, # 0 for CPU usage, 1 for offloading to GPU1
     "stop": ["User:", "\n\n"]
 }
 

--- a/llm_wrapper.py
+++ b/llm_wrapper.py
@@ -86,7 +86,8 @@ class LLMWrapper:
                 'top_p': kwargs.get('top_p', self.llm_config.get('top_p', 0.9)),
                 'stop': kwargs.get('stop', self.llm_config.get('stop', [])),
                 'num_predict': kwargs.get('max_tokens', self.llm_config.get('max_tokens', 55000)),
-                'num_ctx': self.llm_config.get('n_ctx', 55000)
+                'num_ctx': self.llm_config.get('n_ctx', 55000),
+                'num_gpu': self.llm_config.get('num_gpu', 0)
             }
         }
         response = requests.post(url, json=data, stream=True)


### PR DESCRIPTION
Upon testing, when `"num_gpu"` is set to 0, Ollama uses CPU only. When set to 1, it allows offloading to the GPU for split/pure GPU usage if the VRAM permits. When not set, it defaults to 0. This fixes the issues that multiple users have mentioned about using only CPU for the Ollama API.